### PR TITLE
delete unnecessary `vim.print`

### DIFF
--- a/lua/troublesum/config.lua
+++ b/lua/troublesum/config.lua
@@ -35,7 +35,6 @@ M.default_config = {
     end,
     display_summary = function(bufnr, ns, text)
         local line = vim.fn.line("w0") - 1
-        vim.print(line)
         vim.api.nvim_buf_set_extmark(bufnr, ns, line, 0, {
             virt_text = text,
             virt_text_pos = "right_align"


### PR DESCRIPTION
I sent a PR because the print included in the code made it a little unpleasant to see the extra numbers every time I open a new buffer.
Well, I know that we can specify our own function for display_summary, but just in case.